### PR TITLE
Add sample OPA policy repository structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# OPA bundles
+*.tar.gz
+*.bundle
+
+# Editor files
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# OPA Policies
+
+Sample repository demonstrating a basic layout for OPA policies, data, and tests.
+
+## Structure
+
+- `policies/` – Rego policy files
+- `data/` – Static context for policies
+- `tests/` – Rego-based unit tests
+- `bundle/` – Optional bundle assets
+- `ci/` – CI workflow for policy checks
+
+## Testing
+
+Use [OPA](https://www.openpolicyagent.org/) to run the tests:
+
+```bash
+opa test policies tests
+```

--- a/bundle/.manifest
+++ b/bundle/.manifest
@@ -1,0 +1,1 @@
+{"roots": ["policies", "data"]}

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,0 +1,3 @@
+# Bundle
+
+This directory can be used to publish OPA bundles. The `.manifest` file defines the bundle roots.

--- a/ci/policy-checks.yml
+++ b/ci/policy-checks.yml
@@ -1,0 +1,20 @@
+name: policy-checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: open-policy-agent/setup-opa@v1
+        with:
+          version: latest
+      - name: Format
+        run: opa fmt policies/**/*.rego tests/**/*.rego --check
+      - name: Check
+        run: opa check policies tests
+      - name: Test
+        run: opa test policies tests

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -1,0 +1,5 @@
+documents:
+  doc1:
+    owner: alice
+  doc2:
+    owner: bob

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,4 @@
+{
+  "alice": {"role": "admin"},
+  "bob": {"role": "user"}
+}

--- a/example.rego
+++ b/example.rego
@@ -1,8 +1,0 @@
-package example.authz
-
-default allow = false
-
-allow if {
-  input.user == "bob"
-  input.action == "read"
-}

--- a/policies/example/authz.rego
+++ b/policies/example/authz.rego
@@ -1,0 +1,9 @@
+package example.authz
+
+import data.example.helpers
+
+default allow = false
+
+allow {
+    helpers.is_admin(input.user)
+}

--- a/policies/example/helpers.rego
+++ b/policies/example/helpers.rego
@@ -1,0 +1,7 @@
+package example.helpers
+
+import data.example.common
+
+is_admin(user) {
+    data.users[user].role == common.admin_role
+}

--- a/policies/package.rego
+++ b/policies/package.rego
@@ -1,0 +1,3 @@
+package example.common
+
+admin_role := "admin"

--- a/tests/example_authz_test.rego
+++ b/tests/example_authz_test.rego
@@ -1,0 +1,11 @@
+package example.authz_test
+
+import data.example.authz
+
+test_admin_allowed {
+    authz.allow with input as {"user": "alice"}
+}
+
+test_user_denied {
+    not authz.allow with input as {"user": "bob"}
+}


### PR DESCRIPTION
## Summary
- add example authorization and helper policies
- include sample data files and unit tests
- provide bundle manifest, CI workflow, and docs

## Testing
- `opa fmt policies/**/*.rego tests/**/*.rego` *(fails: command not found)*
- `opa test policies tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5ed8bdac832094fb8c75c45184db